### PR TITLE
[DOPS-983] Move docker build-tools to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
         docker {
             label 'd3-build-agent'
             image dockerImage
-            registryUrl 'https://nexus.iroha.tech:19003'
+            registryUrl 'https://docker.soramitsu.co.jp'
             registryCredentialsId 'nexus-build-tools-ro'
             // Uncomment if you need docker sock inside
             // args '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp'


### PR DESCRIPTION
# Task

[DOPS-983]: Move docker build-tools to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-983]: https://soramitsu.atlassian.net/browse/DOPS-983