### PR TITLE
BP-732: Update maps screen

### DIFF
--- a/library/src/main/java/jp/co/soramitsu/map/presentation/SoramitsuMapFragment.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/SoramitsuMapFragment.kt
@@ -125,6 +125,11 @@ class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
             }
         }
 
+        placesWithSearchTextInputEditText.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                searchPanelBottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+            }
+        }
         placesWithSearchTextInputEditText.setOnEditorActionListener { v, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                 inputMethodService?.hideSoftInputFromWindow(v.windowToken, 0)
@@ -494,6 +499,11 @@ class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
         searchPanelBottomSheetBehavior.onStateChanged { newState ->
             if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
                 searchPanelBottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+            }
+
+            if (searchPanelBottomSheetBehavior.state == BottomSheetBehavior.STATE_COLLAPSED) {
+                inputMethodService?.hideSoftInputFromWindow(placesWithSearchTextInputEditText.windowToken, 0)
+                placesWithSearchTextInputEditText.clearFocus()
             }
         }
 


### PR DESCRIPTION
* When search field will be focused, bottom sheet will be expanded
* When search panel collapsed, search field focus will be cleared 
--- 
При получении фокуса будет раскрыта поисковая панель 
При сворачивании панели будет очищен фокус, чтобы при повторном нажатии на edittext у него вызвался `onFocusStateChanged(editText, hasFocus = true)` 