### PR TITLE
BP-732: Update maps screen

### DIFF
--- a/library/src/main/java/jp/co/soramitsu/map/presentation/SoramitsuMapViewModel.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/SoramitsuMapViewModel.kt
@@ -35,6 +35,8 @@ internal class SoramitsuMapViewModel(
         set(value) {
             field = value
 
+            _searchQuery.value = value.query
+
             updateScreen()
         }
 
@@ -44,6 +46,12 @@ internal class SoramitsuMapViewModel(
 
             updateScreen()
         }
+
+    /**
+     * Used to sync fake search field on the map screen and search fragment's search query input field
+     */
+    private val _searchQuery = MutableLiveData<String>("")
+    val searchQuery: LiveData<String> = _searchQuery
 
     fun viewState(): LiveData<SoramitsuMapViewState> = viewState
     fun placeSelected(): LiveData<Place?> = selectedPlaceSingleLiveEvent

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/PlaceFragment.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/PlaceFragment.kt
@@ -178,8 +178,7 @@ internal class PlaceFragment : BottomSheetDialogFragment() {
                 val toTime = dateFormat.format(Date(today.to.inMilliseconds()))
                 val scheduleAsString = resources.getString(R.string.sm_daily_interval, fromTime, toTime)
 
-                val haveLaunchTime = schedule.workingDays[0].launchTimeFrom != null
-                        && schedule.workingDays[0].launchTimeTo != null
+                val haveLaunchTime = today.launchTimeFrom != null && today.launchTimeTo != null
                 if (haveLaunchTime) {
                     val launchFromTime =
                         dateFormat.format(Date(today.launchTimeFrom!!.inMilliseconds()))

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/search/SearchBottomSheetFragment.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/search/SearchBottomSheetFragment.kt
@@ -1,0 +1,127 @@
+package jp.co.soramitsu.map.presentation.search
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import androidx.core.content.ContextCompat
+import androidx.core.view.doOnLayout
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import jp.co.soramitsu.map.R
+import jp.co.soramitsu.map.model.GeoPoint
+import jp.co.soramitsu.map.presentation.SoramitsuMapFragment
+import jp.co.soramitsu.map.presentation.SoramitsuMapViewModel
+import jp.co.soramitsu.map.presentation.places.PlaceFragment
+import jp.co.soramitsu.map.presentation.places.PlacesSearchResultsAdapter
+import kotlinx.android.synthetic.main.sm_search_panel.*
+
+/**
+ * Bottom sheet dialog that is shown when user try to enter something in search
+ * field on maps screen
+ */
+class SearchBottomSheetFragment : BottomSheetDialogFragment() {
+
+    private lateinit var viewModel: SoramitsuMapViewModel
+
+    private val inputMethodService: InputMethodManager?
+        get() = context?.let { context ->
+            ContextCompat.getSystemService(context, InputMethodManager::class.java)
+        }
+
+    private val placesAdapter = PlacesSearchResultsAdapter { place ->
+        viewModel.onPlaceSelected(place)
+        val placePosition = GeoPoint(
+            latitude = place.position.latitude,
+            longitude = place.position.longitude
+        )
+        viewModel.onExtendedPlaceInfoRequested(placePosition)
+
+        dismiss()
+
+        PlaceFragment().show(parentFragmentManager, "Place")
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.sm_search_panel, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // init view model
+        parentFragmentManager.fragments.find { it is SoramitsuMapFragment }?.let { hostFragment ->
+            viewModel = ViewModelProvider(hostFragment, ViewModelProvider.NewInstanceFactory())
+                .get(SoramitsuMapViewModel::class.java)
+        }
+
+        // set transparent background to show rounded corners of the bottom sheet dialog (remove default white background)
+        view.doOnLayout {
+            val parent = (view.parent as? View)
+            parent?.setBackgroundColor(Color.TRANSPARENT)
+
+            dialog?.window?.setDimAmount(0f)
+        }
+
+        // configure list of places
+        placesRecyclerView.adapter = placesAdapter
+        placesRecyclerView.layoutManager = LinearLayoutManager(context)
+
+        // search button click handler
+        placesWithSearchTextInputEditText.setOnEditorActionListener { v, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                inputMethodService?.hideSoftInputFromWindow(v.windowToken, 0)
+
+                val searchText = placesWithSearchTextInputEditText.text?.toString().orEmpty()
+                viewModel.requestParams = viewModel.requestParams.copy(query = searchText)
+            }
+
+            true
+        }
+
+        // clear edit text button click handler
+        placesWithSearchTextInputLayout.setEndIconOnClickListener { v ->
+            placesWithSearchTextInputEditText.text = null
+            viewModel.requestParams = viewModel.requestParams.copy(query = "")
+        }
+
+        // subscribe to places search result
+        viewModel.viewState().observe(viewLifecycleOwner, Observer { viewState ->
+            placesAdapter.update(viewState.places)
+        })
+
+        placesWithSearchTextInputEditText.setText(viewModel.requestParams.query)
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        inputMethodService?.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0)
+        super.onDismiss(dialog)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState)
+        dialog.setOnShowListener {
+            // configure and expand bottom sheet
+            val bottomSheetDialog = dialog as BottomSheetDialog
+            bottomSheetDialog.behavior.isHideable = true
+            bottomSheetDialog.behavior.skipCollapsed = true
+            bottomSheetDialog.behavior.isFitToContents = false
+            bottomSheetDialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+            // request focus on search edit text
+            placesWithSearchTextInputEditText.requestFocus()
+            inputMethodService?.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
+            placesWithSearchTextInputEditText.setSelection(placesWithSearchTextInputEditText.text?.length ?: 0)
+        }
+        return dialog
+    }
+}

--- a/library/src/main/res/layout/sm_fragment_map_soramitsu.xml
+++ b/library/src/main/res/layout/sm_fragment_map_soramitsu.xml
@@ -15,9 +15,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="end|center_vertical"
-        android:padding="16dp"
         android:clipToPadding="false"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="16dp">
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             android:id="@+id/zoomInButton"
@@ -69,6 +69,57 @@
         app:fabSize="mini"
         app:useCompatPadding="true" />
 
-    <include layout="@layout/sm_search_panel" />
+    <FrameLayout
+        android:id="@+id/searchPanelFakeBottomSheet"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/sm_categoriesBottomSheetBackground"
+        android:elevation="12dp"
+        app:behavior_peekHeight="?attr/sm_categoriesBottomSheetPeekHeight"
+        app:layout_behavior="@string/bottom_sheet_behavior">
+
+        <View
+            android:layout_width="?attr/sm_categoriesBottomSheetTopperWidth"
+            android:layout_height="?attr/sm_categoriesBottomSheetTopperHeight"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="8dp"
+            android:background="?attr/sm_categoriesBottomSheetTopperDrawable" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/placesWithSearchTextInputLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="24dp"
+            android:gravity="center_vertical"
+            app:boxBackgroundColor="#F5F5F5"
+            app:boxBackgroundMode="filled"
+            app:boxCornerRadiusBottomEnd="24dp"
+            app:boxCornerRadiusBottomStart="24dp"
+            app:boxCornerRadiusTopEnd="24dp"
+            app:boxCornerRadiusTopStart="24dp"
+            app:boxStrokeWidth="0dp"
+            app:boxStrokeWidthFocused="0dp"
+            app:endIconMode="clear_text"
+            app:hintEnabled="false"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/searchOnFragmentInputEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/sm_search_by_name_hint"
+                android:imeOptions="actionSearch"
+                android:inputType="textFilter"
+                android:maxLines="1"
+                android:paddingTop="12dp"
+                android:textAppearance="?attr/sm_categoriesBottomSheetSearchTextAppearance"
+                android:textColorHint="?attr/sm_categoriesBottomSheetSearchTextHintColor" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+    </FrameLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/library/src/main/res/layout/sm_search_panel.xml
+++ b/library/src/main/res/layout/sm_search_panel.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/searchPanelBottomSheet"
@@ -11,59 +11,67 @@
     app:layout_behavior="@string/bottom_sheet_behavior">
 
     <View
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="24dp"
+        android:background="@android:color/white"
+        />
+
+    <View
         android:layout_width="?attr/sm_categoriesBottomSheetTopperWidth"
         android:layout_height="?attr/sm_categoriesBottomSheetTopperHeight"
+        android:layout_gravity="center_horizontal"
         android:layout_marginTop="8dp"
-        android:background="?attr/sm_categoriesBottomSheetTopperDrawable"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:background="?attr/sm_categoriesBottomSheetTopperDrawable" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/placesWithSearchTextInputLayout"
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginTop="24dp"
-        android:gravity="center_vertical"
-        app:boxBackgroundColor="#F5F5F5"
-        app:boxStrokeWidth="0dp"
-        app:boxStrokeWidthFocused="0dp"
-        app:boxCornerRadiusTopStart="24dp"
-        app:boxCornerRadiusTopEnd="24dp"
-        app:boxCornerRadiusBottomStart="24dp"
-        app:boxCornerRadiusBottomEnd="24dp"
-        app:boxBackgroundMode="filled"
-        app:endIconMode="clear_text"
-        app:hintEnabled="false"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        >
+        android:background="@android:color/transparent"
+        android:paddingStart="16dp"
+        android:paddingTop="24dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="24dp"
+        app:elevation="0dp">
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/placesWithSearchTextInputEditText"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/placesWithSearchTextInputLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="textFilter"
-            android:imeOptions="actionSearch"
-            android:hint="@string/sm_search_by_name_hint"
-            android:maxLines="1"
-            android:paddingTop="12dp"
-            android:textAppearance="?attr/sm_categoriesBottomSheetSearchTextAppearance"
-            android:textColorHint="?attr/sm_categoriesBottomSheetSearchTextHintColor" />
+            android:gravity="center_vertical"
+            app:boxBackgroundColor="#F5F5F5"
+            app:boxBackgroundMode="filled"
+            app:boxCornerRadiusBottomEnd="24dp"
+            app:boxCornerRadiusBottomStart="24dp"
+            app:boxCornerRadiusTopEnd="24dp"
+            app:boxCornerRadiusTopStart="24dp"
+            app:boxStrokeWidth="0dp"
+            app:boxStrokeWidthFocused="0dp"
+            app:endIconMode="clear_text"
+            app:hintEnabled="false">
 
-    </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/placesWithSearchTextInputEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/sm_search_by_name_hint"
+                android:imeOptions="actionSearch"
+                android:inputType="textFilter"
+                android:maxLines="1"
+                android:paddingTop="12dp"
+                android:textAppearance="?attr/sm_categoriesBottomSheetSearchTextAppearance"
+                android:textColorHint="?attr/sm_categoriesBottomSheetSearchTextHintColor" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/placesRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_marginTop="24dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/placesWithSearchTextInputLayout"
-        tools:orientation="vertical"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:listitem="@layout/sm_place_search_result"
-        />
+        tools:orientation="vertical" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
* Used touch listener instead of focus listener to show fullscreen search fragment 
--- 
На экране карт нижняя плашка с полем ввода поиска реализована в виде EditText-а, который НЕ фокусируется, а только отлавливает тачи. Как только пользователь коснулся поля ввода, ему открывается фрагмент, который ставит фокус на обычный edit text вверху экрана 

Зачем это сделано: 
решили, что очень важно, чтобы пользователь не видел нижнюю навигацию вводя поисковый запрос. Чтобы открыть что-то поверх плашки приходится создавать новый диалог, который живет в отдельном окне и перекрывает нижнюю навигационную панель 

Почему не onFocusChangeListener: 
некоторые девайсы (в частности Oppo A5s) постоянно кидают фокус на поле ввода. Зачем они так делают -- загадка, но по этой причине постоянно срабатывает onFocusChanged(edit_text, focused=true)  