### PR TITLE
BP-732: Update maps screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/MainMenuActivityStyle">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/jp/co/soramitsu/map/sample/MainActivity.kt
+++ b/app/src/main/java/jp/co/soramitsu/map/sample/MainActivity.kt
@@ -1,11 +1,16 @@
 package jp.co.soramitsu.map.sample
 
+import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
 import android.view.View
+import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import jp.co.soramitsu.map.presentation.SoramitsuMapFragment
 import kotlinx.android.synthetic.main.activity_main.*
+import kotlin.system.exitProcess
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,5 +36,13 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             bottom_navigation.selectedItemId = R.id.dashboard
         }
+
+        // uncomment for automatic app restart every 20 seconds
+//        Handler().postDelayed({
+//            val intent = packageManager.getLaunchIntentForPackage(packageName)
+//            intent?.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK
+//            startActivity(intent)
+//            exitProcess(0)
+//        }, 20_000)
     }
 }

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/SoramitsuMapFragment.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/SoramitsuMapFragment.kt
@@ -164,7 +164,6 @@ open class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
         super.onPause()
         soramitsuMapView.onPause()
 
-        inputMethodService?.hideSoftInputFromWindow(view?.windowToken, 0)
         handler.removeCallbacksAndMessages(null)
     }
 
@@ -216,6 +215,8 @@ open class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
                     )
                 }
                 onMapScrollStopCallback?.let { handler.postDelayed(it, 500) }
+
+                activity?.onUserInteraction()
             }
 
             viewModel.placeSelected().observe(viewLifecycleOwner, Observer { selectedPlace ->
@@ -226,6 +227,8 @@ open class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
                 searchPanelFakeBottomSheet.visibility = buttonsVisibility
 
                 highlightSelectedPlace()
+
+                activity?.onUserInteraction()
             })
 
             viewModel.viewState().observe(viewLifecycleOwner, Observer { viewState ->
@@ -351,6 +354,8 @@ open class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
     }
 
     private fun onFindMeButtonClicked(googleMap: GoogleMap) {
+        activity?.onUserInteraction()
+
         // check permission and request when not granted. When permissions will
         // be granted, this method will be called again
         val fineLocationPermissionGranted = ActivityCompat.checkSelfPermission(
@@ -385,17 +390,23 @@ open class SoramitsuMapFragment : Fragment(R.layout.sm_fragment_map_soramitsu) {
     private fun initSearchPanel() {
         // show fullscreen search fragment when user try to enter search query
         searchOnFragmentInputEditText.setOnClickListener {
+            activity?.onUserInteraction()
+
             SearchBottomSheetFragment().show(parentFragmentManager, "SearchBottomSheetFragment")
         }
 
         // clear edit text button click handler
         placesWithSearchTextInputLayout.setEndIconOnClickListener { v ->
+            activity?.onUserInteraction()
+
             searchOnFragmentInputEditText.text = null
             viewModel.requestParams = viewModel.requestParams.copy(query = "")
         }
 
         searchOnFragmentInputEditText.setOnTouchListener { v, event ->
             if (event?.action == MotionEvent.ACTION_DOWN) {
+                activity?.onUserInteraction()
+
                 v.performClick()
             }
 


### PR DESCRIPTION
* Used touch listener instead of focus listener to show fullscreen search fragment
* Invoke onUserInteraction every time when user interact with map. It'll prevent force logout after 30 seconds in Bakong
* Removed forced soft keyboard show. It'll fix soft keyboard appearance on pin code screen 
--- 
Убрал принудительную демонстрацию клавиатуры из диалогового фрагмента. Эта клавиатура намертво приклеивалась к экрану и никакие toggleSoftInput и hideSoftInput не могли ее отцепить (даже убийство процесса запросившего клавиатуру не сильно смущало Андроид и он продолжал показывать клавиатуру поверх значков приложения) 

Добавил скрытие панели поиска при проскралливании ниже 50% экрана. Это позволяет избежать ситуации, когда видно сразу 2 поля ввода поиска (одно на карте, второе в диалоге) 

При каждом взаимодействии с экраном карт вызывается onUserInteraction. Это не очень хорошо с той точки зрения, что библиотека ничего не должна знать об особенности приложения в которое она интегрируется, но пока это самое простое решение, делающее Баконг юзабельным на экране карт    