### PR TITLE
BP-1002: Place proposal

### DIFF
--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/DetailedScheduleAdapter.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/DetailedScheduleAdapter.kt
@@ -8,7 +8,9 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import jp.co.soramitsu.map.R
 
-class DetailedScheduleAdapter : RecyclerView.Adapter<DetailedScheduleAdapter.KeyValueViewHolder>() {
+class DetailedScheduleAdapter(
+    private val orientation: Orientation = Orientation.HORIZONTAL
+) : RecyclerView.Adapter<DetailedScheduleAdapter.KeyValueViewHolder>() {
 
     private val items: MutableList<Pair<String, String>> = mutableListOf()
 
@@ -20,9 +22,9 @@ class DetailedScheduleAdapter : RecyclerView.Adapter<DetailedScheduleAdapter.Key
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): KeyValueViewHolder {
-        val itemView = LayoutInflater.from(parent.context)
-            .inflate(R.layout.sm_simple_key_value_list_item, parent, false)
-        return KeyValueViewHolder(itemView)
+        return KeyValueViewHolder(
+            LayoutInflater.from(parent.context).inflate(orientation.layoutResId, parent, false)
+        )
     }
 
     override fun onBindViewHolder(holder: KeyValueViewHolder, position: Int) {
@@ -57,5 +59,10 @@ class DetailedScheduleAdapter : RecyclerView.Adapter<DetailedScheduleAdapter.Key
         override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
             itemsBefore[oldItemPosition] == itemsAfter[newItemPosition]
 
+    }
+
+    enum class Orientation(val layoutResId: Int) {
+        HORIZONTAL(R.layout.sm_simple_key_value_list_item),
+        VERTICAL(R.layout.sm_simple_key_value_list_item_vertical)
     }
 }

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/PlaceProposalFragment.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/PlaceProposalFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
 import com.google.android.gms.maps.model.LatLng
@@ -12,6 +13,7 @@ import jp.co.soramitsu.map.R
 import jp.co.soramitsu.map.model.Category
 import jp.co.soramitsu.map.presentation.places.add.image.*
 import jp.co.soramitsu.map.presentation.places.add.schedule.ScheduleFragmentHost
+import jp.co.soramitsu.map.presentation.places.add.schedule.ScheduleViewModel
 import kotlinx.android.synthetic.main.sm_fragment_place_proposal.*
 
 class PlaceProposalFragment : Fragment(R.layout.sm_fragment_place_proposal),
@@ -20,6 +22,10 @@ class PlaceProposalFragment : Fragment(R.layout.sm_fragment_place_proposal),
     private lateinit var logoAdapter: RemovableImagesAdapter
     private lateinit var photosAdapter: RemovableImagesAdapter
 
+    // shared between PlaceProposalFragment and AddScheduleFragment to
+    // apply schedule changes and display them to user
+    private lateinit var scheduleViewModel: ScheduleViewModel
+
     private val requestManager: RequestManager?
         get() = try {
             Glide.with(this)
@@ -27,14 +33,28 @@ class PlaceProposalFragment : Fragment(R.layout.sm_fragment_place_proposal),
             null
         }
 
+    @ExperimentalStdlibApi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        scheduleViewModel = ViewModelProvider(
+            requireActivity(),
+            ViewModelProvider.NewInstanceFactory()
+        )[ScheduleViewModel::class.java]
+
+        scheduleViewModel.schedule.observe(viewLifecycleOwner) { schedule ->
+            scheduleSection.schedule = schedule
+        }
 
         toolbar.setNavigationOnClickListener { activity?.onBackPressed() }
 
         addressTextView.text = requireArguments().getString(EXTRA_ADDRESS)
 
-        addScheduleTextView.setOnClickListener {
+        scheduleSection.setOnAddButtonClickListener {
+            (activity as? ScheduleFragmentHost)?.showScheduleFragment()
+        }
+
+        scheduleSection.setOnChangeScheduleButtonClickListener {
             (activity as? ScheduleFragmentHost)?.showScheduleFragment()
         }
 

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/ScheduleSectionView.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/ScheduleSectionView.kt
@@ -1,0 +1,96 @@
+package jp.co.soramitsu.map.presentation.places.add
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.Log
+import android.view.View
+import androidx.annotation.LayoutRes
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
+import androidx.transition.TransitionManager
+import jp.co.soramitsu.map.BuildConfig
+import jp.co.soramitsu.map.R
+import jp.co.soramitsu.map.model.Schedule
+import jp.co.soramitsu.map.presentation.places.DetailedScheduleAdapter
+import jp.co.soramitsu.map.presentation.places.add.schedule.generateLaunchTimeFields
+import jp.co.soramitsu.map.presentation.places.add.schedule.generateWorkingDaysFields
+import kotlinx.android.synthetic.main.sm_set_working_hours_section_view.view.*
+
+class ScheduleSectionView @JvmOverloads constructor(
+    context: Context,
+    attributeSet: AttributeSet? = null,
+    defaultStyleResId: Int = 0
+) : ConstraintLayout(context, attributeSet, defaultStyleResId) {
+
+    @ExperimentalStdlibApi
+    var schedule: Schedule? = null
+        set(value) {
+            field = value
+
+            val viewState = if (value != null && value.workingDays.isNotEmpty()) {
+                SectionState.DisplaySchedule(value)
+            } else {
+                SectionState.NoScheduleYet
+            }
+
+            viewState.render()
+        }
+
+    private var onAddButtonClickListener: () -> Unit = {}
+    private var onChangeScheduleButtonClickListener: () -> Unit = {}
+
+    private val adapter = DetailedScheduleAdapter(DetailedScheduleAdapter.Orientation.VERTICAL)
+
+    fun setOnAddButtonClickListener(onAddButtonClickListener: () -> Unit) {
+        this.onAddButtonClickListener = onAddButtonClickListener
+    }
+
+    fun setOnChangeScheduleButtonClickListener(onChangeScheduleButtonClickListener: () -> Unit) {
+        this.onChangeScheduleButtonClickListener = onChangeScheduleButtonClickListener
+    }
+
+    @ExperimentalStdlibApi
+    private fun SectionState.render() = when (this) {
+        is SectionState.DisplaySchedule -> {
+            log("transition to display schedule")
+
+            transitionTo(R.layout.sm_set_working_hours_section_display_schedule_state)
+
+            val workingScheduleAsPairsList = schedule.generateWorkingDaysFields(context)
+            val lunchScheduleAsPairsList = schedule.generateLaunchTimeFields(context)
+            adapter.update(workingScheduleAsPairsList + lunchScheduleAsPairsList)
+        }
+        SectionState.NoScheduleYet -> {
+            log("transition to schedule not set")
+
+            transitionTo(R.layout.sm_set_working_hours_section_display_schedule_state)
+        }
+    }
+
+    private fun transitionTo(@LayoutRes targetStateResId: Int) {
+        val constraintSet = ConstraintSet()
+        constraintSet.load(context, targetStateResId)
+        TransitionManager.beginDelayedTransition(this)
+        constraintSet.applyTo(this)
+    }
+
+    private fun log(message: String) {
+        if (BuildConfig.DEBUG) {
+            Log.d("ScheduleSectionView", message)
+        }
+    }
+
+    init {
+        View.inflate(context, R.layout.sm_set_working_hours_section_view, this)
+
+        workingHoursRecyclerView.adapter = adapter
+
+        addScheduleTextView.setOnClickListener { onAddButtonClickListener.invoke() }
+        changeScheduleTextView.setOnClickListener { onChangeScheduleButtonClickListener.invoke() }
+    }
+
+    private sealed class SectionState {
+        data class DisplaySchedule(val schedule: Schedule) : SectionState()
+        object NoScheduleYet : SectionState()
+    }
+}

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/schedule/AddScheduleFragment.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/schedule/AddScheduleFragment.kt
@@ -17,6 +17,8 @@ import kotlinx.android.synthetic.main.sm_fragment_add_schedule.*
 @ExperimentalStdlibApi
 class AddScheduleFragment : Fragment(R.layout.sm_fragment_add_schedule) {
 
+    // shared between PlaceProposalFragment and AddScheduleFragment to
+    // apply schedule changes and display them to user
     private lateinit var scheduleViewModel: ScheduleViewModel
 
     private var currentScheduleSection: ScheduleSectionView? = null
@@ -39,7 +41,7 @@ class AddScheduleFragment : Fragment(R.layout.sm_fragment_add_schedule) {
         super.onViewCreated(view, savedInstanceState)
 
         scheduleViewModel = ViewModelProvider(
-            this,
+            requireActivity(),
             ViewModelProvider.NewInstanceFactory()
         )[ScheduleViewModel::class.java]
 

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/schedule/CalendarExt.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/schedule/CalendarExt.kt
@@ -1,7 +1,12 @@
 package jp.co.soramitsu.map.presentation.places.add.schedule
 
+import android.content.Context
 import android.content.res.Resources
 import jp.co.soramitsu.map.R
+import jp.co.soramitsu.map.ext.asIntervals
+import jp.co.soramitsu.map.model.Schedule
+import jp.co.soramitsu.map.model.Time
+import java.text.SimpleDateFormat
 import java.time.DayOfWeek
 import java.util.*
 
@@ -25,6 +30,16 @@ fun DayOfWeek.shortLocalisedName(resources: Resources): String = when (this) {
     DayOfWeek.SATURDAY -> resources.getString(R.string.sm_sat_short)
 }
 
+private fun DayOfWeek.localisedName(resources: Resources): String = when (this) {
+    DayOfWeek.SUNDAY -> resources.getString(R.string.sm_sun)
+    DayOfWeek.MONDAY -> resources.getString(R.string.sm_mon)
+    DayOfWeek.TUESDAY -> resources.getString(R.string.sm_tue)
+    DayOfWeek.WEDNESDAY -> resources.getString(R.string.sm_wed)
+    DayOfWeek.THURSDAY -> resources.getString(R.string.sm_thu)
+    DayOfWeek.FRIDAY -> resources.getString(R.string.sm_fri)
+    DayOfWeek.SATURDAY -> resources.getString(R.string.sm_sat)
+}
+
 fun calendarDayToDayOfWeek(calendarDay: Int) = when (calendarDay) {
     Calendar.SUNDAY -> DayOfWeek.SUNDAY
     Calendar.MONDAY -> DayOfWeek.MONDAY
@@ -34,4 +49,85 @@ fun calendarDayToDayOfWeek(calendarDay: Int) = when (calendarDay) {
     Calendar.FRIDAY -> DayOfWeek.FRIDAY
     Calendar.SATURDAY -> DayOfWeek.SATURDAY
     else -> throw IllegalArgumentException()
+}
+
+@ExperimentalStdlibApi
+fun Schedule.generateWorkingDaysFields(context: Context): List<Pair<String, String>> {
+    val dateFormat = SimpleDateFormat("HH:mm", Locale.getDefault()).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+    return asIntervals().map { interval ->
+        val workDay = interval.first
+        val workingInterval = workDay.from != Time.NOT_SET
+                && workDay.to != Time.NOT_SET
+
+        // 6am - 9pm
+        val workingTimeInterval = if (workingInterval) {
+            val fromTime = dateFormat.format(Date(workDay.from.inMilliseconds()))
+            val toTime = dateFormat.format(Date(workDay.to.inMilliseconds()))
+            context.getString(R.string.sm_working_time_interval, fromTime, toTime)
+        } else {
+            context.getString(R.string.sm_closed)
+        }
+
+        val singleDayInterval = interval.first == interval.second
+        if (singleDayInterval) {
+            // sun
+            Pair(
+                calendarDayToDayOfWeek(workDay.weekDay).localisedName(context.resources),
+                workingTimeInterval
+            )
+        } else {
+            // sun - fri
+            val workingDaysInterval = context.getString(
+                R.string.sm_working_days_interval,
+                calendarDayToDayOfWeek(interval.first.weekDay).localisedName(context.resources),
+                calendarDayToDayOfWeek(interval.second.weekDay).localisedName(context.resources)
+            )
+            Pair(workingDaysInterval, workingTimeInterval)
+        }
+    }
+}
+
+@ExperimentalStdlibApi
+fun Schedule.generateLaunchTimeFields(context: Context): List<Pair<String, String>> {
+    return asIntervals { workDay1, workDay2 ->
+        workDay1.lunchTimeFrom == workDay2.lunchTimeFrom &&
+                workDay1.lunchTimeTo == workDay2.lunchTimeTo
+    }.filter { interval ->
+        interval.first.lunchTimeFrom != null
+                && interval.first.lunchTimeFrom != Time.NOT_SET
+                && interval.first.lunchTimeTo != null
+                && interval.first.lunchTimeTo != Time.NOT_SET
+                && interval.second.lunchTimeFrom != null
+                && interval.second.lunchTimeFrom != Time.NOT_SET
+                && interval.second.lunchTimeTo != null
+                && interval.second.lunchTimeTo != Time.NOT_SET
+    }.map { interval ->
+        val dateFormat = SimpleDateFormat("HH:mm", Locale.getDefault()).apply {
+            timeZone = TimeZone.getTimeZone("UTC")
+        }
+
+        val firstDay = interval.first
+        val lastDay = interval.second
+        val fromTime =
+            dateFormat.format(Date(firstDay.lunchTimeFrom!!.inMilliseconds()))
+        val toTime =
+            dateFormat.format(Date(firstDay.lunchTimeTo!!.inMilliseconds()))
+        // 6am - 9pm
+        val launchTimeString = context.getString(R.string.sm_lunch_time_interval, fromTime, toTime)
+        if (firstDay == lastDay) {
+            // lunch time (mon)
+            val lunchTimeSingleDay = context.getString(R.string.sm_lunch_time_single_day, firstDay)
+            Pair(lunchTimeSingleDay, launchTimeString)
+        } else {
+            // lunch time (mon-fri)
+            val lunchDaysInterval = context.getString(
+                R.string.sm_lunch_days_interval,
+                calendarDayToDayOfWeek(firstDay.weekDay).localisedName(context.resources),
+                calendarDayToDayOfWeek(lastDay.weekDay).localisedName(context.resources),
+            )
+            Pair(lunchDaysInterval, launchTimeString)
+        }
+    }
 }

--- a/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/schedule/TimeUtils.kt
+++ b/library/src/main/java/jp/co/soramitsu/map/presentation/places/add/schedule/TimeUtils.kt
@@ -1,0 +1,31 @@
+package jp.co.soramitsu.map.presentation.places.add.schedule
+
+import jp.co.soramitsu.map.model.Time
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.Month
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.time.format.FormatStyle
+
+class TimeUtils {
+
+    companion object {
+        fun formatTime(hour: Int, minute: Int): String {
+            return LocalTime
+                .of(hour, minute)
+                .format(DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT))
+        }
+
+        fun parseTime(localTimeString: String): Time =
+            try {
+                val localDateTime = LocalTime.parse(
+                    localTimeString,
+                    DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
+                )
+                Time(hour = localDateTime.hour, minute = localDateTime.minute)
+            } catch (exception: DateTimeParseException) {
+                Time.NOT_SET
+            }
+    }
+}

--- a/library/src/main/res/layout/sm_fragment_place_proposal.xml
+++ b/library/src/main/res/layout/sm_fragment_place_proposal.xml
@@ -40,7 +40,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:paddingTop="@dimen/sm_margin_padding_size_medium"
-            android:paddingBottom="64dp">
+            android:paddingBottom="@dimen/sm_margin_padding_size_medium">
 
             <com.google.android.material.textfield.TextInputLayout
                 android:id="@+id/placeNameTextInputLayout"
@@ -242,25 +242,10 @@
                 tools:listitem="@layout/sm_removable_image_list_item_56"
                 tools:visibility="visible" />
 
-            <TextView
-                style="?sm_textViewStyleSemiBold15"
+            <jp.co.soramitsu.map.presentation.places.add.ScheduleSectionView
+                android:id="@+id/scheduleSection"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/sm_margin_padding_size_medium"
-                android:padding="@dimen/sm_margin_padding_size_medium"
-                android:text="@string/sm_working_hours" />
-
-            <TextView
-                android:id="@+id/addScheduleTextView"
-                style="?sm_textViewStyleRegular15"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:drawablePadding="@dimen/sm_margin_padding_size_medium"
-                android:background="?selectableItemBackground"
-                android:gravity="center_vertical"
-                android:padding="@dimen/sm_margin_padding_size_medium"
-                android:text="@string/sm_add_schedule"
-                app:drawableStartCompat="@drawable/sm_ic_insert_photo_circle_44" />
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
@@ -272,7 +257,8 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:layout_margin="@dimen/sm_margin_padding_size_medium"
-        android:text="@string/sm_create_and_send_for_review" />
+        android:text="@string/sm_create_and_send_for_review"
+        app:layout_behavior="com.google.android.material.behavior.HideBottomViewOnScrollBehavior" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/library/src/main/res/layout/sm_set_working_hours_section_display_schedule_state.xml
+++ b/library/src/main/res/layout/sm_set_working_hours_section_display_schedule_state.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/workingHoursTitle"
+        style="?sm_textViewStyleSemiBold15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/sm_margin_padding_size_medium"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_working_hours"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/workingHoursRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursTitle"
+        tools:itemCount="3"
+        tools:listitem="@layout/sm_simple_key_value_list_item_vertical" />
+
+    <TextView
+        android:id="@+id/changeScheduleTextView"
+        style="?sm_textViewStyleRegular15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:drawablePadding="@dimen/sm_margin_padding_size_medium"
+        android:gravity="center_vertical"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_change_schedule"
+        app:drawableStartCompat="@drawable/sm_ic_calendar_today_circle_44"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursRecyclerView" />
+
+    <TextView
+        android:id="@+id/addScheduleTextView"
+        style="?sm_textViewStyleRegular15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:drawablePadding="@dimen/sm_margin_padding_size_medium"
+        android:gravity="center_vertical"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_add_schedule"
+        android:visibility="gone"
+        app:drawableStartCompat="@drawable/sm_ic_insert_photo_circle_44"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursRecyclerView" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/layout/sm_set_working_hours_section_no_schedule_state.xml
+++ b/library/src/main/res/layout/sm_set_working_hours_section_no_schedule_state.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/workingHoursTitle"
+        style="?sm_textViewStyleSemiBold15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/sm_margin_padding_size_medium"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_working_hours"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/workingHoursRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursTitle"
+        tools:itemCount="3"
+        tools:listitem="@layout/sm_simple_key_value_list_item_vertical" />
+
+    <TextView
+        android:id="@+id/changeScheduleTextView"
+        style="?sm_textViewStyleRegular15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:drawablePadding="@dimen/sm_margin_padding_size_medium"
+        android:gravity="center_vertical"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_change_schedule"
+        android:visibility="gone"
+        app:drawableStartCompat="@drawable/sm_ic_calendar_today_circle_44"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursRecyclerView" />
+
+    <TextView
+        android:id="@+id/addScheduleTextView"
+        style="?sm_textViewStyleRegular15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:drawablePadding="@dimen/sm_margin_padding_size_medium"
+        android:gravity="center_vertical"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_add_schedule"
+        app:drawableStartCompat="@drawable/sm_ic_insert_photo_circle_44"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursRecyclerView" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/layout/sm_set_working_hours_section_view.xml
+++ b/library/src/main/res/layout/sm_set_working_hours_section_view.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/workingHoursTitle"
+        style="?sm_textViewStyleSemiBold15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/sm_margin_padding_size_medium"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_working_hours"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/workingHoursRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursTitle"
+        tools:itemCount="3"
+        tools:listitem="@layout/sm_simple_key_value_list_item_vertical" />
+
+    <TextView
+        android:id="@+id/changeScheduleTextView"
+        style="?sm_textViewStyleRegular15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:drawablePadding="@dimen/sm_margin_padding_size_medium"
+        android:gravity="center_vertical"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_change_schedule"
+        android:visibility="gone"
+        app:drawableStartCompat="@drawable/sm_ic_calendar_today_circle_44"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursRecyclerView" />
+
+    <TextView
+        android:id="@+id/addScheduleTextView"
+        style="?sm_textViewStyleRegular15"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?selectableItemBackground"
+        android:drawablePadding="@dimen/sm_margin_padding_size_medium"
+        android:gravity="center_vertical"
+        android:padding="@dimen/sm_margin_padding_size_medium"
+        android:text="@string/sm_add_schedule"
+        app:drawableStartCompat="@drawable/sm_ic_insert_photo_circle_44"
+        app:layout_constraintTop_toBottomOf="@id/workingHoursRecyclerView" />
+
+</merge>

--- a/library/src/main/res/layout/sm_simple_key_value_list_item_vertical.xml
+++ b/library/src/main/res/layout/sm_simple_key_value_list_item_vertical.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/placeBottomSheet"
+    android:paddingStart="@dimen/sm_margin_padding_size_medium"
+    android:paddingEnd="@dimen/sm_margin_padding_size_medium"
+    android:paddingTop="@dimen/sm_margin_padding_size_small"
+    android:paddingBottom="@dimen/sm_margin_padding_size_small"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+
+    <TextView
+        android:id="@+id/keyTextView"
+        style="@style/SM.Widget.Soramitsu.TextView.Regular14"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Mon-Thu"
+        />
+
+    <TextView
+        android:id="@+id/valueTextView"
+        style="@style/SM.Widget.Soramitsu.TextView.Regular15"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@id/keyTextView"
+        app:layout_constraintTop_toBottomOf="@id/keyTextView"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:text="6:30 AM- 8:30 PM"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="sm_to">To</string>
     <string name="sm_save">Save</string>
     <string name="sm_add_opening_hours">Add opening hours %1$s</string>
+    <string name="sm_change_schedule">Change schedule</string>
 
     <plurals name="sm_reviews_format">
         <item quantity="one">(%1$d review)</item>

--- a/library/src/test/java/jp/co/soramitsu/map/presentation/places/add/schedule/ScheduleViewModelTest.kt
+++ b/library/src/test/java/jp/co/soramitsu/map/presentation/places/add/schedule/ScheduleViewModelTest.kt
@@ -119,8 +119,9 @@ class ScheduleViewModelTest {
             )
         }
 
-        assertThat(viewModel.schedule.open24).isFalse()
-        assertThat(viewModel.schedule.workingDays).isEqualTo(
+        val schedule = viewModel.schedule.value
+        assertThat(schedule?.open24).isFalse()
+        assertThat(schedule?.workingDays).isEqualTo(
             listOf(
                 workDay(Calendar.SUNDAY),
                 workDay(Calendar.MONDAY),

--- a/library/src/test/java/jp/co/soramitsu/map/presentation/places/add/schedule/TimeUtilsTest.kt
+++ b/library/src/test/java/jp/co/soramitsu/map/presentation/places/add/schedule/TimeUtilsTest.kt
@@ -1,0 +1,34 @@
+package jp.co.soramitsu.map.presentation.places.add.schedule
+
+import com.google.common.truth.Truth.assertThat
+import jp.co.soramitsu.map.model.Time
+import org.junit.Ignore
+import org.junit.Test
+import java.util.*
+
+class TimeUtilsTest {
+
+    @Test
+    @Ignore("Passed local, failed on CI. Need to fix: https://bakong.atlassian.net/browse/BP-1027")
+    fun `time to string`() {
+        Locale.setDefault(Locale("RU"))
+        assertThat(TimeUtils.formatTime(4, 20)).isEqualTo("04:20")
+        assertThat(TimeUtils.formatTime(16, 20)).isEqualTo("16:20")
+
+        Locale.setDefault(Locale.US)
+        assertThat(TimeUtils.formatTime(4, 20)).isEqualTo("4:20 AM")
+        assertThat(TimeUtils.formatTime(16, 20)).isEqualTo("4:20 PM")
+    }
+
+    @Test
+    @Ignore("Passed local, failed on CI. Need to fix: https://bakong.atlassian.net/browse/BP-1027")
+    fun `parse time`() {
+        Locale.setDefault(Locale("RU"))
+        assertThat(TimeUtils.parseTime("04:20")).isEqualTo(Time(4, 20))
+        assertThat(TimeUtils.parseTime("16:20")).isEqualTo(Time(16, 20))
+
+        Locale.setDefault(Locale.US)
+        assertThat(TimeUtils.parseTime("4:20 AM")).isEqualTo(Time(4, 20))
+        assertThat(TimeUtils.parseTime("4:20 PM")).isEqualTo(Time(16, 20))
+    }
+}


### PR DESCRIPTION
* Added ScheduleSection to display schedule summary in proposal fragment
* ScheduleViewModel shared between screens to notify PlaceProposalFragment about schedule changes. This notification will trigger ScheduleSectionView update
* DetailedScheduleAdapter modified to display items in horizontal or vertical orientation depending of the screen (UI requirements) 
--- 
Добавлена секция для отображения расписания на экране ввода информации о месте 
Вью модель шарится между экранами чтобы передавать сообщения об изменениях в расписание. По нажатию на кнопку `save` из `List<SectionsData>`, содержащего введенные юзером данные о времени работы, формируется Schedule, который через вью модель передается на  PlaceProposalFragment. PlaceProposalFragment получая сообщение об изменении расписания перерисовывает секцию с расписанием 
Адаптер модифицирован, т.к. на 2-х разные экранах немного разное отображение расписания 

<img width="518" alt="Screenshot 2021-02-02 at 17 21 41" src="https://user-images.githubusercontent.com/5954000/106615766-d68fd580-657d-11eb-9fc7-51835cea56c1.png">
<img width="518" alt="Screenshot 2021-02-02 at 17 21 47" src="https://user-images.githubusercontent.com/5954000/106615780-da235c80-657d-11eb-83e6-4fcaa6500b4e.png">
